### PR TITLE
Add simple client-side auth with cookies

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
       <ul class="menu">
         <li><a href="#features">Features</a></li>
         <li><a href="#about">About</a></li>
+        <li><a href="#auth">Log in</a></li>
         <li><a class="btn btn-primary" href="#contact">Contact</a></li>
       </ul>
     </nav>
@@ -67,6 +68,41 @@
       <div class="card">
         <h2>About</h2>
         <p>This starter keeps the stack simple so you can focus on content. Add pages, components, or plug into your n8n webhooks.</p>
+      </div>
+    </section>
+
+    <section id="auth" class="section">
+      <h2 class="center">Account access</h2>
+      <div class="grid auth-grid">
+        <article class="card">
+          <h3>Create an account</h3>
+          <p class="muted">Stored in plain text for demo purposes only.</p>
+          <form id="signup-form" class="stack">
+            <label for="signup-username">Username</label>
+            <input id="signup-username" type="text" autocomplete="username" required />
+            <label for="signup-password">Password</label>
+            <input id="signup-password" type="password" autocomplete="new-password" required />
+            <button class="btn btn-primary" type="submit">Sign up</button>
+          </form>
+          <details id="user-dump">
+            <summary>View stored users (insecure demo)</summary>
+            <pre id="user-dump-content" aria-live="polite">[]</pre>
+          </details>
+        </article>
+
+        <article class="card">
+          <h3>Log in</h3>
+          <p id="auth-status" class="muted"></p>
+          <form id="login-form" class="stack">
+            <label for="login-username">Username</label>
+            <input id="login-username" type="text" autocomplete="username" required />
+            <label for="login-password">Password</label>
+            <input id="login-password" type="password" autocomplete="current-password" required />
+            <button class="btn btn-primary" type="submit">Log in</button>
+          </form>
+          <button id="logout-btn" class="btn" type="button" hidden>Log out</button>
+          <p id="auth-message" class="muted"></p>
+        </article>
       </div>
     </section>
 

--- a/script.js
+++ b/script.js
@@ -2,7 +2,138 @@
 document.addEventListener('DOMContentLoaded', () => {
   const yearEl = document.getElementById('year');
   if (yearEl) yearEl.textContent = new Date().getFullYear();
+  initAuth();
 });
+
+const USER_DB_KEY = 'mysite-user-db';
+const USER_COOKIE = 'mysite-user';
+
+function initAuth() {
+  const signupForm = document.getElementById('signup-form');
+  const loginForm = document.getElementById('login-form');
+  const logoutBtn = document.getElementById('logout-btn');
+  const authMessage = document.getElementById('auth-message');
+  const statusEl = document.getElementById('auth-status');
+
+  if (!signupForm && !loginForm) return;
+
+  updateAuthUI();
+  renderUserDump();
+
+  signupForm?.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const username = signupForm.querySelector('#signup-username')?.value.trim();
+    const password = signupForm.querySelector('#signup-password')?.value;
+
+    if (!username || !password) {
+      updateAuthUI('Please provide both a username and password.');
+      return;
+    }
+
+    const users = loadUsers();
+    if (users.some((user) => user.username === username)) {
+      updateAuthUI('That username is already taken.');
+      return;
+    }
+
+    users.push({ username, password });
+    saveUsers(users);
+    signupForm.reset();
+    updateAuthUI('Account created. You can log in now.');
+    renderUserDump(users);
+  });
+
+  loginForm?.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const username = loginForm.querySelector('#login-username')?.value.trim();
+    const password = loginForm.querySelector('#login-password')?.value;
+
+    const users = loadUsers();
+    const foundUser = users.find((user) => user.username === username);
+
+    if (!username || !password || !foundUser || foundUser.password !== password) {
+      updateAuthUI('Invalid username or password.');
+      return;
+    }
+
+    setCookie(USER_COOKIE, username);
+    loginForm.reset();
+    updateAuthUI('Logged in successfully.');
+    renderUserDump(users);
+  });
+
+  logoutBtn?.addEventListener('click', () => {
+    deleteCookie(USER_COOKIE);
+    updateAuthUI('Logged out.');
+    renderUserDump();
+  });
+
+  function updateAuthUI(feedbackMessage) {
+    const currentUser = getCookie(USER_COOKIE);
+
+    if (statusEl) {
+      statusEl.textContent = currentUser
+        ? `Logged in as ${currentUser}`
+        : 'Not logged in.';
+    }
+
+    if (logoutBtn) logoutBtn.hidden = !currentUser;
+    if (loginForm) loginForm.hidden = !!currentUser;
+
+    if (authMessage) {
+      authMessage.textContent = feedbackMessage ?? '';
+    }
+  }
+}
+
+function loadUsers() {
+  const raw = localStorage.getItem(USER_DB_KEY);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.warn('Failed to parse user database:', error);
+    return [];
+  }
+}
+
+function saveUsers(users) {
+  localStorage.setItem(USER_DB_KEY, JSON.stringify(users));
+}
+
+function renderUserDump(users = loadUsers()) {
+  const target = document.getElementById('user-dump-content');
+  if (!target) return;
+
+  if (!users.length) {
+    target.textContent = '[]';
+    target.setAttribute('data-empty', 'true');
+    return;
+  }
+
+  target.textContent = JSON.stringify(users, null, 2);
+  target.removeAttribute('data-empty');
+}
+
+function setCookie(name, value) {
+  document.cookie = `${name}=${encodeURIComponent(value)}; path=/`;
+}
+
+function getCookie(name) {
+  const cookies = document.cookie.split(';');
+  for (const cookie of cookies) {
+    const [key, ...rest] = cookie.trim().split('=');
+    if (key === name) {
+      return decodeURIComponent(rest.join('='));
+    }
+  }
+  return null;
+}
+
+function deleteCookie(name) {
+  document.cookie = `${name}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+}
 
 // === THEME PERSISTENCE + TOGGLE ============================================
 // Modes: "light", "dark", "auto"

--- a/styles.css
+++ b/styles.css
@@ -284,6 +284,7 @@ h3 {
 
 input[type=text],
 input[type=email],
+input[type=password],
 textarea {
   width: 100%;
   padding: .75em .85em;
@@ -298,6 +299,38 @@ input:focus,
 textarea:focus {
   border-color: var(--primary);
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary) 25%, transparent);
+}
+
+#auth-status {
+  min-height: 1.6em;
+}
+
+#auth-message {
+  min-height: 1.6em;
+}
+
+#user-dump {
+  margin-top: 12px;
+  font-size: .9rem;
+}
+
+#user-dump summary {
+  cursor: pointer;
+  color: var(--muted);
+}
+
+#user-dump[open] summary {
+  color: var(--text);
+}
+
+#user-dump pre {
+  margin: 10px 0 0;
+  background: var(--bg);
+  border: 1px dashed var(--border);
+  border-radius: 10px;
+  padding: 12px;
+  overflow: auto;
+  max-height: 200px;
 }
 
 .footer {


### PR DESCRIPTION
## Summary
- add an account section with sign-up and login forms
- store demo credentials in localStorage and set an insecure cookie to track the session
- update styles for password fields and auth messaging
- expose a collapsible viewer of the stored demo users for quick verification on the test branch

## Testing
- Not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d663e63c0c832f803c62a27801274c